### PR TITLE
Add jq to dependencies

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,6 +17,7 @@ RUN dpkg --add-architecture i386 && \
 		mailutils \
 		postfix \
 		bc \
+		jq \
 		curl \
 		wget \
 		file \


### PR DESCRIPTION
noticed that the scripts kept complaining about missing "jq" dependency