### PR TITLE
Fixed volume permission issue

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -60,14 +60,18 @@ RUN dpkg --add-architecture i386 && \
 RUN wget https://linuxgsm.com/dl/linuxgsm.sh
 
 ## user config
-RUN adduser --disabled-password --gecos "" lgsm && \
+RUN groupadd -g 750 -o lgsm && \
+	adduser --uid 750 --disabled-password --gecos "" --ingroup lgsm lgsm && \
 	chown lgsm:lgsm /linuxgsm.sh && \
 	chmod +x /linuxgsm.sh && \
 	cp /linuxgsm.sh /home/lgsm/linuxgsm.sh && \
-	usermod -G tty lgsm
+	usermod -G tty lgsm && \
+	chown -R lgsm:lgsm /home/lgsm/ && \
+	chmod 755 /home/lgsm
 
 USER lgsm
 WORKDIR /home/lgsm
+VOLUME [ "/home/lgsm" ]
 
 # need use xterm for LinuxGSM
 ENV TERM=xterm

--- a/README.md
+++ b/README.md
@@ -16,3 +16,10 @@ Dockerhub https://hub.docker.com/r/gameservermanagers/linuxgsm-docker/
 
 Run Game Servers in Docker, multiplex multiple LinuxGSM deployments easily by taking advantage of Dockers port mapping.
 
+## Installation
+This will work both on linux and Docker for Windows. With Docker for Windows, skip the first command and make a folder the normal way. When running the container, Docker for Windows may ask for permission to access the folder. Simply allow this action.
+
+```bash
+$ mkdir -p /path/to/lgsm && sudo chown -R 750:750 /path/to/lgsm
+$ docker run --name lgsm-docker --restart always --net=host --hostname LGSM -it -v "/path/to/lgsm:/home/lgsm/" lgsm-docker
+```


### PR DESCRIPTION
When mounting a volume in docker, it defaults to root. As of now, docker does not support mounting as a specific user. The workaround is to make a folder on the host with the owner set to the uid of the container user. The problem that was caused here is that you could not install a game or add any files to /home/lgsm. This should solve it