### PR TITLE
improvement: let docker do what tmux used to. and define gameserver as an environment variable.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,8 +15,9 @@ ENV LANG en_US.utf8
 
 ## Base System
 RUN dpkg --add-architecture i386 && \
-	apt update -y && \
-	apt install -y \
+	apt-get update -y && \
+	apt-get install -y \
+                iproute2\
 		mailutils \
 		postfix \
 		curl \
@@ -66,36 +67,21 @@ RUN dpkg --add-architecture i386 && \
 		&& apt-get clean \
 	  && rm -rf /var/lib/apt/lists/*
 
-# Add the linuxgsm user
-RUN adduser \
-      --disabled-login \
-      --disabled-password \
-      --shell /bin/bash \
-      --gecos "" \
-      linuxgsm \
-    && usermod -G tty linuxgsm \
-    && chown -R linuxgsm:linuxgsm /home/linuxgsm
-
-# Switch to the user linuxgsm
-USER linuxgsm
-
-
-## linuxgsm.sh
-RUN wget https://linuxgsm.com/dl/linuxgsm.sh
 
 ## user config
 RUN groupadd -g 750 -o linuxgsm && \
 	adduser --uid 750 --disabled-password --gecos "" --ingroup linuxgsm linuxgsm && \
-	chown linuxgsm:linuxgsm /linuxgsm.sh && \
-	chmod +x /linuxgsm.sh && \
-	cp /linuxgsm.sh /home/linuxgsm/linuxgsm.sh && \
 	usermod -G tty linuxgsm && \
 	chown -R linuxgsm:linuxgsm /home/linuxgsm/ && \
 	chmod 755 /home/linuxgsm
 
+# Switch to the user linuxgsm
 USER linuxgsm
 WORKDIR /home/linuxgsm
-VOLUME [ "/home/linuxgsm" ]
+
+## linuxgsm.sh
+RUN wget https://linuxgsm.com/dl/linuxgsm.sh -O ~/linuxgsm.sh && chmod +x ~/linuxgsm.sh
+VOLUME [ "/home/linuxgsm" ] # define volume _after_ download.
 
 # need use xterm for LinuxGSM
 ENV TERM=xterm

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,78 +9,82 @@ LABEL maintainer="LinuxGSM <me@danielgibbs.co.uk>"
 
 ENV DEBIAN_FRONTEND noninteractive
 
-RUN apt-get update && apt-get install -y locales && rm -rf /var/lib/apt/lists/* \
-    && localedef -i en_US -c -f UTF-8 -A /usr/share/locale/locale.alias en_US.UTF-8
+RUN apt-get update \
+ && apt-get install -y locales \
+ && rm -rf /var/lib/apt/lists/* \
+ && localedef -i en_US -c -f UTF-8 -A /usr/share/locale/locale.alias en_US.UTF-8
+
 ENV LANG en_US.utf8
 
 ## Base System
-RUN dpkg --add-architecture i386 && \
-	apt-get update -y && \
-	apt-get install -y \
-                iproute2\
-		mailutils \
-		postfix \
-		curl \
-		wget \
-		file \
-		bzip2 \
-		gzip \
-		unzip \
-		bsdmainutils \
-		python \
-		util-linux \
-		binutils \
-		bc \
-		jq \
-		tmux \
-		lib32gcc1 \
-		libstdc++6 \
-		libstdc++6:i386 \
-		apt-transport-https \
-		ca-certificates \
-		telnet \
-		expect \
-		libncurses5:i386 \
-		libcurl4-gnutls-dev:i386 \
-		libstdc++5:i386 \
-		lib32tinfo5 \
-		xz-utils \
-		zlib1g:i386 \
-		libldap-2.4-2:i386 \
-		lib32z1 \
-		default-jre \
-		speex:i386 \
-		libtbb2 \
-		libxrandr2:i386 \
-		libglu1-mesa:i386 \
-		libxtst6:i386 \
-		libusb-1.0-0:i386 \
-		libopenal1:i386 \
-		libpulse0:i386 \
-		libdbus-glib-1-2:i386 \
-		libnm-glib4:i386 \
-		zlib1g \
-		libssl1.0.0:i386 \
-		libtcmalloc-minimal4:i386 \
-		libsdl1.2debian \
-		libnm-glib-dev:i386 \
-		&& apt-get clean \
-	  && rm -rf /var/lib/apt/lists/*
+RUN dpkg --add-architecture i386 \
+ && apt-get update -y \
+ && apt-get install -y iproute2\
+                       mailutils \
+                       postfix \
+                       curl \
+                       wget \
+                       file \
+                       bzip2 \
+                       gzip \
+                       unzip \
+                       bsdmainutils \
+                       python \
+                       util-linux \
+                       binutils \
+                       bc \
+                       jq \
+                       tmux \
+                       lib32gcc1 \
+                       libstdc++6 \
+                       libstdc++6:i386 \
+                       apt-transport-https \
+                       ca-certificates \
+                       telnet \
+                       expect \
+                       libncurses5:i386 \
+                       libcurl4-gnutls-dev:i386 \
+                       libstdc++5:i386 \
+                       lib32tinfo5 \
+                       xz-utils \
+                       zlib1g:i386 \
+                       libldap-2.4-2:i386 \
+                       lib32z1 \
+                       default-jre \
+                       speex:i386 \
+                       libtbb2 \
+                       libxrandr2:i386 \
+                       libglu1-mesa:i386 \
+                       libxtst6:i386 \
+                       libusb-1.0-0:i386 \
+                       libopenal1:i386 \
+                       libpulse0:i386 \
+                       libdbus-glib-1-2:i386 \
+                       libnm-glib4:i386 \
+                       zlib1g \
+                       libssl1.0.0:i386 \
+                       libtcmalloc-minimal4:i386 \
+                       libsdl1.2debian \
+                       libnm-glib-dev:i386 \
+ && apt-get clean \
+ && rm -rf /var/lib/apt/lists/*
 
 
 ## user config
-RUN groupadd -g 750 -o linuxgsm && \
-	adduser --uid 750 --disabled-password --gecos "" --ingroup linuxgsm linuxgsm && \
-	usermod -G tty linuxgsm && \
-	chown -R linuxgsm:linuxgsm /home/linuxgsm/ && \
-	chmod 755 /home/linuxgsm
+RUN groupadd -g 750 -o linuxgsm \
+ && adduser --uid 750 --disabled-password --gecos "" --ingroup linuxgsm linuxgsm \
+ && usermod -G tty linuxgsm \
+ && chown -R linuxgsm:linuxgsm /home/linuxgsm/ \
+ && chmod 755 /home/linuxgsm
 
 # Switch to the user linuxgsm
 USER linuxgsm
 WORKDIR /home/linuxgsm
 
 ## linuxgsm.sh
-RUN wget https://linuxgsm.com/dl/linuxgsm.sh -O ~/linuxgsm.sh && chmod +x ~/linuxgsm.sh
+RUN wget https://linuxgsm.com/dl/linuxgsm.sh -O ~/linuxgsm.sh \
+ && chmod +x ~/linuxgsm.sh
+
 VOLUME [ "/home/linuxgsm" ] # define volume _after_ download.
 
 # need use xterm for LinuxGSM

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@ LABEL maintainer="LinuxGSM <me@danielgibbs.co.uk>"
 ENV DEBIAN_FRONTEND noninteractive
 
 RUN apt-get update \
- && apt-get install -y locales \
+ && apt-get install --no-install-recommends -y locales \
  && rm -rf /var/lib/apt/lists/* \
  && localedef -i en_US -c -f UTF-8 -A /usr/share/locale/locale.alias en_US.UTF-8
 
@@ -19,7 +19,8 @@ ENV LANG en_US.utf8
 ## Base System
 RUN dpkg --add-architecture i386 \
  && apt-get update -y \
- && apt-get install -y iproute2\
+ && apt-get install -y --no-install-recommends\
+                       iproute2\
                        mailutils \
                        postfix \
                        curl \

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,6 @@
+version: '3.3'
+services:
+  quake2:
+    build: .
+    environment:
+      - GAMESERVER=q2server

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -11,24 +11,18 @@
 ## then we must keep a backup copy of the script on local drive
 if [ ! -e ~/linuxgsm.sh ]; then
     echo "Initializing Linuxgsm User Script in New Volume"
-    cp /linuxgsm.sh ./linuxgsm.sh
+    wget https://linuxgsm.com/dl/linuxgsm.sh -O ~/linuxgsm.sh && chmod +x ~/linuxgsm.sh
 fi
 
-# with no command, just spawn a running container suitable for exec's
+# with no command, just run the game (or try)
 if [ $# = 0 ]; then
-    tail -f /dev/null
+    if [ ! -e "$GAMESERVER" ]; then
+        echo "Installing $GAMESERVER"
+        ./linuxgsm.sh $GAMESERVER && ./$GAMESERVER auto-install
+    fi
+    echo "Launching $GAMESERVER (IN DEBUG MODE)"
+    echo Y | ./$GAMESERVER debug
 else
     # execute the command passed through docker
     "$@"
-
-    # if this command was a server start cmd
-    # to get around LinuxGSM running everything in
-    # tmux;
-    # we attempt to attach to tmux to track the server
-    # this keeps the container running
-    # when invoked via docker run
-    # but requires -it or at least -t
-    tmux set -g status off && tmux attach 2> /dev/null
 fi
-
-exit 0

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -18,10 +18,10 @@ fi
 if [ $# = 0 ]; then
     if [ ! -e "$GAMESERVER" ]; then
         echo "Installing $GAMESERVER"
-        ./linuxgsm.sh $GAMESERVER && ./$GAMESERVER auto-install
+        ./linuxgsm.sh "$GAMESERVER" && "./$GAMESERVER" auto-install
     fi
     echo "Launching $GAMESERVER (IN DEBUG MODE)"
-    echo Y | ./$GAMESERVER debug
+    echo Y | "./$GAMESERVER" debug
 else
     # execute the command passed through docker
     "$@"


### PR DESCRIPTION
Hi, people. I guess there is no easy way to run the server in foreground other than debug mode, right?

However, I did this, and it *probably* no longer needs tmux. (I don't know LinuxGSM well enough and I only tested Quake2)

If there are nontrivial consequences from running a server permanently in debug mode, please tell me.