### PR TITLE
Fix dependencies

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,6 +17,7 @@ ENV LANG en_US.utf8
 RUN dpkg --add-architecture i386 && \
 	apt update -y && \
 	apt install -y \
+                iproute2 \
 		mailutils \
 		postfix \
 		curl \

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,7 +17,7 @@ ENV LANG en_US.utf8
 RUN dpkg --add-architecture i386 && \
 	apt update -y && \
 	apt install -y \
-                iproute2 \
+		iproute2 \
 		mailutils \
 		postfix \
 		curl \


### PR DESCRIPTION
Lgsm uses the 'ip' command several times. The docker image is missing
this command. The missing command is part of the package 'iproute2'.