### PR TITLE
style: Better shell debugging with Docker builds

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,85 +5,95 @@
 #
 
 FROM ubuntu:18.04
+
 LABEL maintainer="LinuxGSM <me@danielgibbs.co.uk>"
 
 ENV DEBIAN_FRONTEND noninteractive
 
-RUN apt-get update && apt-get install -y locales && rm -rf /var/lib/apt/lists/* \
-    && localedef -i en_US -c -f UTF-8 -A /usr/share/locale/locale.alias en_US.UTF-8
+RUN set -ex; \
+apt-get update; \
+apt-get install -y locales; \
+rm -rf /var/lib/apt/lists/*; \
+localedef -i en_US -c -f UTF-8 -A /usr/share/locale/locale.alias en_US.UTF-8
+
 ENV LANG en_US.utf8
 
 ## Base System
-RUN dpkg --add-architecture i386 && \
-	apt update -y && \
-	apt install -y \
-		iproute2 \
-		mailutils \
-		postfix \
-		curl \
-		wget \
-		file \
-		bzip2 \
-		gzip \
-		unzip \
-		bsdmainutils \
-		python \
-		util-linux \
-		binutils \
-		bc \
-		jq \
-		tmux \
-		lib32gcc1 \
-		libstdc++6 \
-		libstdc++6:i386 \
-		apt-transport-https \
-		ca-certificates \
-		telnet \
-		expect \
-		libncurses5:i386 \
-		libcurl4-gnutls-dev:i386 \
-		libstdc++5:i386 \
-		netcat \
-		lib32stdc++6 \		
-		lib32tinfo5 \
-		xz-utils \
-		zlib1g:i386 \
-		libldap-2.4-2:i386 \
-		lib32z1 \
-		default-jre \
-		speex:i386 \
-		libtbb2 \
-		libxrandr2:i386 \
-		libglu1-mesa:i386 \
-		libxtst6:i386 \
-		libusb-1.0-0:i386 \
-		libopenal1:i386 \
-		libpulse0:i386 \
-		libdbus-glib-1-2:i386 \
-		libnm-glib4:i386 \
-		zlib1g \
-		libssl1.0.0:i386 \
-		libtcmalloc-minimal4:i386 \
-		libsdl1.2debian \
-		libnm-glib-dev:i386 \
-		&& apt-get clean \
-	  && rm -rf /var/lib/apt/lists/*
+RUN set -ex; \
+dpkg --add-architecture i386; \
+apt update -y; \
+apt install -y \
+    apt-transport-https \
+    bc \
+    binutils \
+    bsdmainutils \
+    bzip2 \
+    ca-certificates \
+    curl \
+    default-jre \
+    expect \
+    file \
+    gzip \
+    iproute2 \
+    jq \
+    lib32gcc1 \
+    lib32stdc++6 \
+    lib32tinfo5 \
+    lib32z1 \
+    libcurl4-gnutls-dev:i386 \
+    libdbus-glib-1-2:i386 \
+    libglu1-mesa:i386 \
+    libldap-2.4-2:i386 \
+    libncurses5:i386 \
+    libnm-glib-dev:i386 \
+    libnm-glib4:i386 \
+    libopenal1:i386 \
+    libpulse0:i386 \
+    libsdl1.2debian \
+    libssl1.0.0:i386 \
+    libstdc++5:i386 \
+    libstdc++6 \
+    libstdc++6:i386 \
+    libtbb2 \
+    libtcmalloc-minimal4:i386 \
+    libusb-1.0-0:i386 \
+    libxrandr2:i386 \
+    libxtst6:i386 \
+    mailutils \
+    netcat \
+    postfix \
+    python \
+    speex:i386 \
+    telnet \
+    tmux \
+    unzip \
+    util-linux \
+    wget \
+    xz-utils \
+    zlib1g \
+    zlib1g:i386; \
+apt-get clean; \
+rm -rf /var/lib/apt/lists/*
 
 ## linuxgsm.sh
-RUN wget https://linuxgsm.com/dl/linuxgsm.sh
+RUN set -ex; \
+wget https://linuxgsm.com/dl/linuxgsm.sh
 
 ## user config
-RUN groupadd -g 750 -o linuxgsm && \
-	adduser --uid 750 --disabled-password --gecos "" --ingroup linuxgsm linuxgsm && \
-	chown linuxgsm:linuxgsm /linuxgsm.sh && \
-	chmod +x /linuxgsm.sh && \
-	cp /linuxgsm.sh /home/linuxgsm/linuxgsm.sh && \
-	usermod -G tty linuxgsm && \
-	chown -R linuxgsm:linuxgsm /home/linuxgsm/ && \
-	chmod 755 /home/linuxgsm
+RUN set -ex; \
+groupadd -g 750 -o linuxgsm; \
+adduser --uid 750 --disabled-password --gecos "" --ingroup linuxgsm linuxgsm; \
+chown linuxgsm:linuxgsm /linuxgsm.sh; \
+chmod +x /linuxgsm.sh; \
+cp /linuxgsm.sh /home/linuxgsm/linuxgsm.sh; \
+usermod -G tty linuxgsm; \
+chown -R linuxgsm:linuxgsm /home/linuxgsm/; \
+chmod 755 /home/linuxgsm
 
 USER linuxgsm
+
 WORKDIR /home/linuxgsm
+
 VOLUME [ "/home/linuxgsm" ]
 
 # need use xterm for LinuxGSM
@@ -93,4 +103,5 @@ ENV TERM=xterm
 ENV PATH=$PATH:/home/linuxgsm
 
 COPY entrypoint.sh /entrypoint.sh
+
 ENTRYPOINT ["bash","/entrypoint.sh" ]


### PR DESCRIPTION
Every `RUN` step in Docker launches a `/bin/sh` subshell.  Because of this, you can use standard shell options supported by `/bin/sh`.

> **Please Note**: I have not added or removed anything from the Docker image.  I just added a few debug options to make build output more clear.

Changes made:

- Every `RUN` step starts with `set -ex`.  Refer to [The Set Builtin in the Bash manual][1] to learn more about `set -e` and `set -x` respectively.
- Because `set -ex` is used, semi-colon commands and ampersand separated commands have the same effect... bash will exit on first error.  So I changed all of the commands to be semi-colon separated.

  ```bash
  command1 && command2

  # the following means the exact same thing
  set -ex;
  command1;
  command2;
  ```

- I de-indented all of the `RUN` commands.  It's my personal opinion that all commands should be de-indented unless they're sub-options to a preceding command (like the package list on `apt-get install`).  Every Dockerfile command should be separated by a blank newline for readability.
- In the `apt-get install` package list which lists one package per line, I sorted the package list.

# How has this changed behavior?

When you run the following command:

    docker build . -t lgsm

You will now see shell commands show up in red as they are executed.  e.g. you'll see every `apt-get` command, `rm`, and any other commands run as they're executed.  So if one of the commands throws an error you'll see which command was the problem, specifically.

[1]: https://www.gnu.org/software/bash/manual/html_node/The-Set-Builtin.html#The-Set-Builtin