### PR TITLE
Minor Dockerfile Improvements

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,8 +18,6 @@ localedef -i en_US -c -f UTF-8 -A /usr/share/locale/locale.alias en_US.UTF-8
 
 ENV LANG en_US.utf8
 
-
-
 ## Base System
 RUN set -ex; \
 dpkg --add-architecture i386; \

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,12 +18,14 @@ localedef -i en_US -c -f UTF-8 -A /usr/share/locale/locale.alias en_US.UTF-8
 
 ENV LANG en_US.utf8
 
+
+
 ## Base System
 RUN set -ex; \
 dpkg --add-architecture i386; \
 apt update -y; \
 apt install -y \
-    vi \
+    vim \
     apt-transport-https \
     bc \
     binutils \
@@ -51,6 +53,7 @@ apt install -y \
     libopenal1:i386 \
     libpulse0:i386 \
     libsdl1.2debian \
+    libsdl2-2.0-0:i386 \
     libssl1.0.0:i386 \
     libstdc++5:i386 \
     libstdc++6 \

--- a/Dockerfile
+++ b/Dockerfile
@@ -23,6 +23,7 @@ RUN set -ex; \
 dpkg --add-architecture i386; \
 apt update -y; \
 apt install -y \
+    vi \
     apt-transport-https \
     bc \
     binutils \


### PR DESCRIPTION
Fixes #22 to edit config files
Fixes a dependency issue with SDL2 being required instead of 1.2. I left that version in case other packages needed to reference it. 

Built the image locally and used it to start a Valheim server without any further errors.