### PR TITLE
Feat: docker-compose example

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,6 @@ This will work both on linux and Docker for Windows. With Docker for Windows, sk
 
 ```bash
 $ mkdir -p /path/to/lgsm && sudo chown -R 750:750 /path/to/lgsm
-$ docker run -d --name lgsm-docker --restart always --net=host --hostname LGSM -it -v "/path/to/lgsm:/home/lgsm/" gameservermanagers/linuxgsm-docker
+$ docker run -d --name lgsm-docker --restart always --net=host --hostname LGSM -it -v "/path/to/lgsm:/home/linuxgsm/" gameservermanagers/linuxgsm-docker
 ```
 To expose multiple game ports for your server use the format `-p <start-stop>:<start-stop>`. For example `docker run -d --name <server name> -p 12203-12204:12203-12204 --restart-always --net=host gameservermanagers/linuxgsm-docker `

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,0 +1,9 @@
+services:
+    linuxgsm:
+        image: gameservermanagers/linuxgsm-docker
+        container_name: lgsm-docker
+        hostname: 'LGSM'
+        network_mode: host
+        volumes:
+          - '/path/to/lgsm:/home/linuxgsm'
+        restart: always


### PR DESCRIPTION
Added a docker-compose.yaml example that matches the docker run example from PR #28 1:1 functionally. Intention is to set up a nice stable base to begin adding features to. 