### PR TITLE
add exec statement to entrypoint

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -31,4 +31,4 @@ else
     tmux set -g status off && tmux attach 2> /dev/null
 fi
 
-exit 0
+exec "$@"


### PR DESCRIPTION
Added `exec "$@"` to the end of the entrypoint to match common practices.

https://stackoverflow.com/questions/32255814/what-purpose-does-using-exec-in-docker-entrypoint-scripts-serve/32261019#32261019
https://unix.stackexchange.com/questions/466999/what-does-exec-do