### PR TITLE
Feat: user permissions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,9 +6,14 @@
 
 FROM ubuntu:18.04
 
+RUN ln -s -f /bin/true /usr/bin/chfn
+
 LABEL maintainer="LinuxGSM <me@danielgibbs.co.uk>"
 
 ENV DEBIAN_FRONTEND noninteractive
+
+ENV PUID=750
+ENV PGID=750
 
 RUN set -ex; \
 apt-get update; \
@@ -73,18 +78,19 @@ apt install -y \
     wget \
     xz-utils \
     zlib1g \
+    gosu \
     zlib1g:i386; \
 apt-get clean; \
 rm -rf /var/lib/apt/lists/*
 
 ## linuxgsm.sh
 RUN set -ex; \
-wget https://linuxgsm.com/dl/linuxgsm.sh
+wget -O linuxgsm.sh https://linuxgsm.sh
 
 ## user config
 RUN set -ex; \
-groupadd -g 750 -o linuxgsm; \
-adduser --uid 750 --disabled-password --gecos "" --ingroup linuxgsm linuxgsm; \
+groupadd -g "${PGID}" -o linuxgsm; \
+adduser --uid "${PUID}" --disabled-password --gecos "" --ingroup linuxgsm linuxgsm; \
 chown linuxgsm:linuxgsm /linuxgsm.sh; \
 chmod +x /linuxgsm.sh; \
 cp /linuxgsm.sh /home/linuxgsm/linuxgsm.sh; \
@@ -105,5 +111,7 @@ ENV TERM=xterm
 ENV PATH=$PATH:/home/linuxgsm
 
 COPY entrypoint.sh /entrypoint.sh
+
+USER root
 
 ENTRYPOINT ["bash","/entrypoint.sh" ]

--- a/README.md
+++ b/README.md
@@ -24,6 +24,6 @@ This will work both on linux and Docker for Windows. With Docker for Windows, sk
 
 ```bash
 $ mkdir -p /path/to/lgsm && sudo chown -R 750:750 /path/to/lgsm
-$ docker run -d --name lgsm-docker --restart always --net=host --hostname LGSM -it -v "/path/to/lgsm:/home/linuxgsm/" gameservermanagers/linuxgsm-docker
+$ docker run -d --name lgsm-docker --restart always --net=host --hostname LGSM -it -e PUID=750 -e PGID=750 -v "/path/to/lgsm:/home/linuxgsm/" gameservermanagers/linuxgsm-docker
 ```
 To expose multiple game ports for your server use the format `-p <start-stop>:<start-stop>`. For example `docker run -d --name <server name> -p 12203-12204:12203-12204 --restart-always --net=host gameservermanagers/linuxgsm-docker `

--- a/README.md
+++ b/README.md
@@ -24,6 +24,6 @@ This will work both on linux and Docker for Windows. With Docker for Windows, sk
 
 ```bash
 $ mkdir -p /path/to/lgsm && sudo chown -R 750:750 /path/to/lgsm
-$ docker run -d --name lgsm-docker --restart always --net=host --hostname LGSM -it -v "/path/to/lgsm:/home/lgsm/" gameservermanagers/linuxgsm-docker
+$ docker run -d --name lgsm-docker --restart always --net=host --hostname LGSM -it -v "/path/to/lgsm:/home/linuxgsm/" gameservermanagers/linuxgsm-docker
 ```
 To expose multiple game ports for your server use the format `-p <start-stop>:<start-stop>`. For example `docker run -d --name <server name> -p 12203-12204:12203-12204 --restart-always --net=host gameservermanagers/linuxgsm-docker `

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -4,6 +4,9 @@ services:
         container_name: lgsm-docker
         hostname: 'LGSM'
         network_mode: host
+        environment:
+          - PUID=750
+          - PGID=750
         volumes:
           - '/path/to/lgsm:/home/linuxgsm'
         restart: always

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,0 +1,9 @@
+services:
+    linuxgsm:
+        image: gameservermanagers/linuxgsm-docker
+        container_name: lgsm-docker
+        hostname: 'LGSM'
+        network_mode: host
+        volumes:
+          - '/path/to/lgsm:/home/linuxgsm'
+        restart: always

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -2,7 +2,6 @@
 ## linuxgsm-docker base image entrypoint script
 ## execute LinuxGSM or arbitrary server commands at will
 ## by passing command
-set -x
 PUID=${PUID:-750}
 PGID=${PGID:-750}
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -2,7 +2,25 @@
 ## linuxgsm-docker base image entrypoint script
 ## execute LinuxGSM or arbitrary server commands at will
 ## by passing command
+set -x
+PUID=${PUID:-750}
+PGID=${PGID:-750}
 
+groupmod -o -g ${PGID} linuxgsm
+usermod -o -u ${PUID} linuxgsm
+
+echo '
+-------------------------------------
+GID/UID
+-------------------------------------'
+echo "
+User uid:    $(id -u linuxgsm)
+User gid:    $(id -g linuxgsm)
+-------------------------------------
+"
+chown -R ${PUID}:${PGID} /home/linuxgsm/
+
+gosu linuxgsm bash
 
 ## Because of a limitation in LinuxGSM script it must be run from the directory
 ## It is installed in.


### PR DESCRIPTION
Added environmental variables PUID and PGID that can be used to match container user and host user to same ID # for easy file management.
To do This I added gosu to the installed packages and added commands to the entrypoint.
Also updated docker-compose.yaml and docker run examples to include the new environmental variables. Need to add instructions to the readme on how to use.