### PR TITLE
feat: add user flag

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,6 +17,7 @@ ENV LANG en_US.utf8
 RUN dpkg --add-architecture i386 && \
 	apt update -y && \
 	apt install -y \
+                iproute2 \
 		mailutils \
 		postfix \
 		curl \

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,85 +5,95 @@
 #
 
 FROM ubuntu:18.04
+
 LABEL maintainer="LinuxGSM <me@danielgibbs.co.uk>"
 
 ENV DEBIAN_FRONTEND noninteractive
 
-RUN apt-get update && apt-get install -y locales && rm -rf /var/lib/apt/lists/* \
-    && localedef -i en_US -c -f UTF-8 -A /usr/share/locale/locale.alias en_US.UTF-8
+RUN set -ex; \
+apt-get update; \
+apt-get install -y locales; \
+rm -rf /var/lib/apt/lists/*; \
+localedef -i en_US -c -f UTF-8 -A /usr/share/locale/locale.alias en_US.UTF-8
+
 ENV LANG en_US.utf8
 
 ## Base System
-RUN dpkg --add-architecture i386 && \
-	apt update -y && \
-	apt install -y \
-		iproute2 \
-		mailutils \
-		postfix \
-		curl \
-		wget \
-		file \
-		bzip2 \
-		gzip \
-		unzip \
-		bsdmainutils \
-		python \
-		util-linux \
-		binutils \
-		bc \
-		jq \
-		tmux \
-		lib32gcc1 \
-		libstdc++6 \
-		libstdc++6:i386 \
-		apt-transport-https \
-		ca-certificates \
-		telnet \
-		expect \
-		libncurses5:i386 \
-		libcurl4-gnutls-dev:i386 \
-		libstdc++5:i386 \
-		netcat \
-		lib32stdc++6 \		
-		lib32tinfo5 \
-		xz-utils \
-		zlib1g:i386 \
-		libldap-2.4-2:i386 \
-		lib32z1 \
-		default-jre \
-		speex:i386 \
-		libtbb2 \
-		libxrandr2:i386 \
-		libglu1-mesa:i386 \
-		libxtst6:i386 \
-		libusb-1.0-0:i386 \
-		libopenal1:i386 \
-		libpulse0:i386 \
-		libdbus-glib-1-2:i386 \
-		libnm-glib4:i386 \
-		zlib1g \
-		libssl1.0.0:i386 \
-		libtcmalloc-minimal4:i386 \
-		libsdl1.2debian \
-		libnm-glib-dev:i386 \
-		&& apt-get clean \
-	  && rm -rf /var/lib/apt/lists/*
+RUN set -ex; \
+dpkg --add-architecture i386; \
+apt update -y; \
+apt install -y \
+    apt-transport-https \
+    bc \
+    binutils \
+    bsdmainutils \
+    bzip2 \
+    ca-certificates \
+    curl \
+    default-jre \
+    expect \
+    file \
+    gzip \
+    iproute2 \
+    jq \
+    lib32gcc1 \
+    lib32stdc++6 \
+    lib32tinfo5 \
+    lib32z1 \
+    libcurl4-gnutls-dev:i386 \
+    libdbus-glib-1-2:i386 \
+    libglu1-mesa:i386 \
+    libldap-2.4-2:i386 \
+    libncurses5:i386 \
+    libnm-glib-dev:i386 \
+    libnm-glib4:i386 \
+    libopenal1:i386 \
+    libpulse0:i386 \
+    libsdl1.2debian \
+    libssl1.0.0:i386 \
+    libstdc++5:i386 \
+    libstdc++6 \
+    libstdc++6:i386 \
+    libtbb2 \
+    libtcmalloc-minimal4:i386 \
+    libusb-1.0-0:i386 \
+    libxrandr2:i386 \
+    libxtst6:i386 \
+    mailutils \
+    netcat \
+    postfix \
+    python \
+    speex:i386 \
+    telnet \
+    tmux \
+    unzip \
+    util-linux \
+    wget \
+    xz-utils \
+    zlib1g \
+    zlib1g:i386; \
+apt-get clean; \
+rm -rf /var/lib/apt/lists/*
 
 ## linuxgsm.sh
-RUN wget https://linuxgsm.com/dl/linuxgsm.sh
+RUN set -ex; \
+wget https://linuxgsm.com/dl/linuxgsm.sh
 
 ## user config
-RUN groupadd -g 750 -o linuxgsm && \
-	adduser --uid 750 --disabled-password --gecos "" --ingroup linuxgsm linuxgsm && \
-	chown linuxgsm:linuxgsm /linuxgsm.sh && \
-	chmod +x /linuxgsm.sh && \
-	cp /linuxgsm.sh /home/linuxgsm/linuxgsm.sh && \
-	usermod -G tty linuxgsm && \
-	chown -R linuxgsm:linuxgsm /home/linuxgsm/ && \
-	chmod 755 /home/linuxgsm
+RUN set -ex; \
+groupadd -g 750 -o linuxgsm; \
+adduser --uid 750 --disabled-password --gecos "" --ingroup linuxgsm linuxgsm; \
+chown linuxgsm:linuxgsm /linuxgsm.sh; \
+chmod +x /linuxgsm.sh; \
+cp /linuxgsm.sh /home/linuxgsm/linuxgsm.sh; \
+usermod -G tty linuxgsm; \
+chown -R linuxgsm:linuxgsm /home/linuxgsm/; \
+chmod 755 /home/linuxgsm
 
 USER linuxgsm
+
 WORKDIR /home/linuxgsm
+
 VOLUME [ "/home/linuxgsm" ]
 
 # need use xterm for LinuxGSM
@@ -93,4 +103,5 @@ ENV TERM=xterm
 ENV PATH=$PATH:/home/linuxgsm
 
 COPY entrypoint.sh /entrypoint.sh
+
 ENTRYPOINT ["bash","/entrypoint.sh" ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -69,20 +69,6 @@ RUN dpkg --add-architecture i386 && \
 		&& apt-get clean \
 	  && rm -rf /var/lib/apt/lists/*
 
-# Add the linuxgsm user
-RUN adduser \
-      --disabled-login \
-      --disabled-password \
-      --shell /bin/bash \
-      --gecos "" \
-      linuxgsm \
-    && usermod -G tty linuxgsm \
-    && chown -R linuxgsm:linuxgsm /home/linuxgsm
-
-# Switch to the user linuxgsm
-USER linuxgsm
-
-
 ## linuxgsm.sh
 RUN wget https://linuxgsm.com/dl/linuxgsm.sh
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -23,6 +23,7 @@ RUN set -ex; \
 dpkg --add-architecture i386; \
 apt update -y; \
 apt install -y \
+    vim \
     apt-transport-https \
     bc \
     binutils \
@@ -50,6 +51,7 @@ apt install -y \
     libopenal1:i386 \
     libpulse0:i386 \
     libsdl1.2debian \
+    libsdl2-2.0-0:i386 \
     libssl1.0.0:i386 \
     libstdc++5:i386 \
     libstdc++6 \

--- a/Dockerfile
+++ b/Dockerfile
@@ -43,6 +43,8 @@ RUN dpkg --add-architecture i386 && \
 		libncurses5:i386 \
 		libcurl4-gnutls-dev:i386 \
 		libstdc++5:i386 \
+		netcat \
+		lib32stdc++6 \		
 		lib32tinfo5 \
 		xz-utils \
 		zlib1g:i386 \

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,7 +17,7 @@ ENV LANG en_US.utf8
 RUN dpkg --add-architecture i386 && \
 	apt update -y && \
 	apt install -y \
-                iproute2 \
+		iproute2 \
 		mailutils \
 		postfix \
 		curl \

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2017 Andrey Shmakov
+Copyright (c) 2017-2020 Daniel Gibbs
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -24,5 +24,6 @@ This will work both on linux and Docker for Windows. With Docker for Windows, sk
 
 ```bash
 $ mkdir -p /path/to/lgsm && sudo chown -R 750:750 /path/to/lgsm
-$ docker run --name lgsm-docker --restart always --net=host --hostname LGSM -it -v "/path/to/lgsm:/home/lgsm/" gameservermanagers/linuxgsm-docker
+$ docker run -d --name lgsm-docker --restart always --net=host --hostname LGSM -it -v "/path/to/lgsm:/home/lgsm/" gameservermanagers/linuxgsm-docker
 ```
+To expose multiple game ports for your server use the format `-p <start-stop>:<start-stop>`. For example `docker run -d --name <server name> -p 12203-12204:12203-12204 --restart-always --net=host gameservermanagers/linuxgsm-docker `

--- a/README.md
+++ b/README.md
@@ -23,7 +23,8 @@ Run Game Servers in Docker, multiplex multiple LinuxGSM deployments easily by ta
 This will work both on linux and Docker for Windows. With Docker for Windows, skip the first command and make a folder the normal way. When running the container, Docker for Windows may ask for permission to access the folder. Simply allow this action.
 
 ```bash
-$ mkdir -p /path/to/lgsm && sudo chown -R 750:750 /path/to/lgsm
-$ docker run -d --name lgsm-docker --restart always --net=host --hostname LGSM -it -v "/path/to/lgsm:/home/linuxgsm/" gameservermanagers/linuxgsm-docker
+$ mkdir -p /path/to/lgsm
+$ docker run -d --name lgsm-docker --restart always --net=host --user 750:750 --hostname LGSM -it -v "/path/to/lgsm:/home/linuxgsm/" gameservermanagers/linuxgsm-docker
 ```
+To make all files compatible with your user on the host change ``750:750`` to your preferred user's uid and gid. 
 To expose multiple game ports for your server use the format `-p <start-stop>:<start-stop>`. For example `docker run -d --name <server name> -p 12203-12204:12203-12204 --restart-always --net=host gameservermanagers/linuxgsm-docker `

--- a/README.md
+++ b/README.md
@@ -24,6 +24,6 @@ This will work both on linux and Docker for Windows. With Docker for Windows, sk
 
 ```bash
 $ mkdir -p /path/to/lgsm && sudo chown -R 750:750 /path/to/lgsm
-$ docker run -d --name lgsm-docker --restart always --net=host --hostname LGSM -it -v "/path/to/lgsm:/home/lgsm/" gameservermanagers/linuxgsm-docker
+$ docker run -d --name lgsm-docker --restart always --net=host --hostname LGSM -it -v "/path/to/lgsm:/home/linuxgsm/" gameservermanagers/linuxgsm-docker
 ```
 To expose multiple game ports for your server use the format `-p <start-stop>:<start-stop>`. For example `docker run -d --name <server name> -p 12203-12204:12203-12204 --restart-always --net=host gameservermanagers/linuxgsm-docker `

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -3,6 +3,7 @@ services:
         image: gameservermanagers/linuxgsm-docker
         container_name: lgsm-docker
         hostname: 'LGSM'
+        user: '750:750'
         network_mode: host
         volumes:
           - '/path/to/lgsm:/home/linuxgsm'

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,0 +1,9 @@
+services:
+    linuxgsm:
+        image: gameservermanagers/linuxgsm-docker
+        container_name: lgsm-docker
+        hostname: 'LGSM'
+        network_mode: host
+        volumes:
+          - '/path/to/lgsm:/home/linuxgsm'
+        restart: always

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -31,4 +31,4 @@ else
     tmux set -g status off && tmux attach 2> /dev/null
 fi
 
-exit 0
+exec "$@"


### PR DESCRIPTION
These new args in the docker run example and docker compose example will now dictate what uid and gid are assigned to linuxgsm inside of the dockerfile. This is a better implementation of PR #33 that follows best practices more closely.