### PR TITLE
Fix entrypoint trap handler

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -59,7 +59,8 @@ echo "start ${GAMESERVER}"
 sleep 5
 ./${GAMESERVER} details
 
-tail -f log/script/*
+tail -f log/script/* &
+wait $!
 
 # with no command, just spawn a running container suitable for exec's
 if [ $# = 0 ]; then


### PR DESCRIPTION
Hi, just wanted to suggest a simple addition to this script which fixes the trap handler. Tail prevents the SIGTERM signal from being handled by the trap at the top of the script. By using wait, it ensures that the signal is caught and handled by the trap.

For reference on the tail -f thing: https://stackoverflow.com/questions/49507830/sigterm-signal-not-caught-when-the-last-process-is-tail

PS: this is my first time making a pull request so im sorry if im pushing to the wrong branch or something. just really love this docker image and wanted to help :)