### PR TITLE
Use the executable created by linuxgsm

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -36,7 +36,11 @@ fi
 # Setup game server
 if [ ! -f "${GAMESERVER}" ]; then
     echo "creating ./${GAMESERVER}"
-   ./linuxgsm.sh ${GAMESERVER}
+    exec_name=$(./linuxgsm.sh ${GAMESERVER} | grep -o ${GAMESERVER}-. | head -1)
+    if [ -z "$exec_name" ]; then
+        exec_name=${GAMESERVER}
+    fi
+    export GAMESERVER=$exec_name
 fi
 
 # Install game server

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -37,10 +37,9 @@ fi
 if [ ! -f "${GAMESERVER}" ]; then
     echo "creating ./${GAMESERVER}"
     exec_name=$(./linuxgsm.sh ${GAMESERVER} | grep -o ${GAMESERVER}-. | head -1)
-    if [ -z "$exec_name" ]; then
-        exec_name=${GAMESERVER}
+    if [ ! -z "$exec_name" ]; then
+        export GAMESERVER=$exec_name
     fi
-    export GAMESERVER=$exec_name
 fi
 
 # Install game server


### PR DESCRIPTION
When the linuxgsm creates the game server executable file, the entrypoint is assuming $GAMESERVER is the name of the exec.
Or if the exec has been created before but is not executable (by the touch command) the linuxgsm will install a new instance (which have "-2" added to its name) but the script doesn't use this new name.
So I just did a grep to get the new file name, and then replace the GAMESERVER env variable. This new value is then used to install, update and start the server.